### PR TITLE
Add simple prometheus metrics

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     ],
     keywords=['jabber', 'xmpp', 'bridge', 'bot', 'webhook', 'webhooks'],
     packages=find_packages(),
-    install_requires=['aiohttp', 'pyyaml', 'slixmpp'],
+    install_requires=['aiohttp', 'pyyaml', 'slixmpp', 'prometheus_client'],
     entry_points={
         'console_scripts': [
             'xmppwb=xmppwb.core:main',

--- a/xmppwb/core.py
+++ b/xmppwb/core.py
@@ -12,10 +12,11 @@ import asyncio
 import logging
 import os
 import sys
+
 import yaml
 
-from xmppwb.bridge import XMPPWebhookBridge, InvalidConfigError
 from xmppwb import __version__
+from xmppwb.bridge import XMPPWebhookBridge, InvalidConfigError
 
 
 def main():
@@ -25,8 +26,8 @@ def main():
     """
     parser = argparse.ArgumentParser(
         description="A bot that bridges XMPP (chats and MUCs) with webhooks, "
-        "thus making it possible to interact with services outside the XMPP "
-        "world.")
+                    "thus making it possible to interact with services outside the XMPP "
+                    "world.")
     parser.add_argument("-c", "--config", help="set the config file",
                         required=True)
     parser.add_argument("-v", "--verbose", help="increase output verbosity",
@@ -57,10 +58,8 @@ def main():
     if args.logfile:
         log_config['filename'] = args.logfile
 
-
     logging.getLogger('slixmpp').setLevel(logging.WARNING)
     logging.getLogger('aiohttp').setLevel(logging.WARNING)
-    # logger = logging.getLogger('xmppwb')
     logging.basicConfig(**log_config)
 
     logging.info("Starting xmppwb version {}".format(__version__))

--- a/xmppwb/prometheus.py
+++ b/xmppwb/prometheus.py
@@ -1,0 +1,18 @@
+import prometheus_client as pc
+from xmppwb.xmpp import XMPPBridgeBot
+
+
+class Metrics:
+    connection_active = pc.Gauge("xmppwb_xmpp_connection_active", "Indicates if the xmpp connection is still active (1)")
+    messages_sent = pc.Counter("xmppwb_messages_sent", "Count of messages sent to xmpp muc")
+
+    @classmethod
+    def check_connection_active(cls, xmpp_client: XMPPBridgeBot):
+        if xmpp_client.is_connected():
+            cls.connection_active.set(1)
+        else:
+            cls.connection_active.set(0)
+
+    @classmethod
+    def increment_messages_sent(cls):
+        cls.messages_sent.inc(1)

--- a/xmppwb/xmpp.py
+++ b/xmppwb/xmpp.py
@@ -8,6 +8,7 @@ This module implements the XMPP specific parts of the bridge.
 :license: MIT, see LICENSE for more details.
 """
 import logging
+
 from slixmpp import ClientXMPP
 
 
@@ -16,6 +17,7 @@ class XMPPBridgeBot(ClientXMPP):
     MUCs, listens to incoming messages (from both MUCs and normal chats) and
     sends messages.
     """
+
     def __init__(self, jid, password, main_bridge):
         ClientXMPP.__init__(self, jid, password)
 
@@ -39,7 +41,7 @@ class XMPPBridgeBot(ClientXMPP):
 
         for muc, nickname in self.main_bridge.mucs.items():
             logging.debug("Joining MUC '{}' using nickname '{}'.".format(
-                                                                muc, nickname))
+                muc, nickname))
             if muc in self.main_bridge.muc_passwords:
                 self.plugin['xep_0045'].join_muc(
                     muc,


### PR DESCRIPTION
This adds a prometheus endpoint under /metrics which serves two metrics:
* xmppwb_xmpp_connection_active indicates if the xmpp connection is
  still active
* xmppwb_messages_sent_total provides a counter on how many messages
  were sent to the configured xmpp muc